### PR TITLE
Add defensive header to prevent conflicts with embedding page

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -45,6 +45,10 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Host $http_host;
 
+        # Fixes issues with embedded maps where embedding page declares HTTP header:
+        #  Referrer-Policy:no-referrer
+        # IF we have some services relying on the Referer header being sent to it
+        add_header Referrer-Policy origin always;
         # set all cookies to secure, httponly and samesite by modifying "path"
         proxy_cookie_path / "/; secure; HttpOnly; SameSite=lax";
     }


### PR DESCRIPTION
Fixes issues with embedded maps where embedding page declares HTTP header: `Referrer-Policy:no-referrer`. Services that are called by the embedded map that rely on the Referer header being sent to it don't work without this.

Fixes issues with macOS/Safari at least. Other envs seem to default to this anyway at this point of time.