### PR TITLE
Switch to new bundle impls

### DIFF
--- a/jetty-9/oskari-server/resources/oskari-ext.properties
+++ b/jetty-9/oskari-server/resources/oskari-ext.properties
@@ -105,7 +105,7 @@ actionhandler.GetAppSetup.dynamic.bundle.admin-users.roles = Admin
 actionhandler.GetAppSetup.dynamic.bundle.admin.roles = Admin
 
 # Drop bundles for mobile users
-actionhandler.GetAppSetup.desktopOnly.bundles = publisher2, statsgrid, mydata, myplaces3, printout, myplacesimport, featuredata2, metadataflyout, metadatacatalogue
+actionhandler.GetAppSetup.desktopOnly.bundles = publisher2, statsgrid, mydata, myplaces3, printout, myplacesimport, featuredata, metadataflyout, metadatasearch
 
 ##################################
 # CSW-metadata configuration


### PR DESCRIPTION
The sample app now uses `featuredata` (instead of `featuredata2`) and `metadatasearch` (intead of `metadatacatalogue`)